### PR TITLE
Update kamon libraries version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,10 +4,10 @@ version := "1.0-SNAPSHOT"
 
 scalaVersion := "2.11.8"
 
-val kamonCore         = "io.kamon"                  %%  "kamon-core"            % "1.0.0-RC7"
-val kamonExecutors    = "io.kamon"                  %%  "kamon-executors"       % "1.0.0-RC7"
-val kamonScala        = "io.kamon"                  %%  "kamon-scala-future"    % "1.0.0-RC7"
-val kamonTestkit      = "io.kamon"                  %%  "kamon-testkit"         % "1.0.0-RC7"
+val kamonCore         = "io.kamon"                  %%  "kamon-core"            % "1.1.3"
+val kamonExecutors    = "io.kamon"                  %%  "kamon-executors"       % "1.0.1"
+val kamonScala        = "io.kamon"                  %%  "kamon-scala-future"    % "1.0.0"
+val kamonTestkit      = "io.kamon"                  %%  "kamon-testkit"         % "1.1.3"
 
 val dockerTestKit     = "com.whisk"                 %% "docker-testkit-scalatest" % "0.9.5"
 val dockerTestKitSpotify = "com.whisk"              %% "docker-testkit-impl-spotify" % "0.9.5"


### PR DESCRIPTION
Update io.kamon libraries to latest version:
- kamon-core to 1.1.3
- kamon-executors to 1.0.1
- kamon-scala-future to 1.0.0
- kamon-testkit to 1.1.3