### PR TITLE
update installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ Supported releases and dependencies are shown below.
 
 | kamon-mongo | reactivemongo | status | jdk  | scala            
 |:-----------:|:-------------:|:------:|:----:|------
-|  0.0.1 | 0.12 until 0.16 | stable  | 1.8+ | 2.11, 2.12
+|  0.0.4 | 0.12 until 0.16 | stable  | 1.8+ | 2.11, 2.12
 
 
 To get started with SBT, simply add the following to your `build.sbt` file:
 
 ```scala
 resolvers += "jitpack" at "https://jitpack.io"
-libraryDependencies += "com.github.jtjeferreira" % "kamon-mongo" % "0.0.1"
+libraryDependencies += "com.github.jtjeferreira" %% "kamon-mongo" % "0.0.4"
 ```
 
 ### Metrics ###


### PR DESCRIPTION
Had to make a few changes to get this working on scala 2.12 with kamon 1.1.2. Updated the readme with what I ended up using. Note - I did not test 0.0.4 at all, I just noticed it is listed in the jitpack repo so I assume it works with 2.11.